### PR TITLE
Update readme with more tested usage (but for Job)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "distroless",
+        "jdbc",
         "nonroot"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ For a Docker Compose setup, you can have a `.env`-file with with variables in, a
 ```yaml
 services:
 
-  hapi_fhir_cli_tool:
-    container_name: "HAPI-FHIR-CLI-Tool"
+  hapi_fhir_cli:
+    container_name: "HAPI-FHIR-CLI"
     image: ghcr.io/trifork/hapi-fhir-cli:latest
     depends_on:
       - hapi

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ spec:
             - name: DB_URL
               valueFrom:
                 configMapKeyRef:
-                  name: secret-name
+                  name: config-map-name
                   key: DB_CONN
 
             - name: DB_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: secret-name
+                  name: config-map-name
                   key: DB_PORT
 
             - name: DB_NAME

--- a/README.md
+++ b/README.md
@@ -4,28 +4,96 @@ Repo for building daily releases of the HAPI FHIR CLI if a new version is availa
 
 ## Usage
 
+This image is a distroless image, which means there is no `sh` or `bash` to configure it with.
+The image will launch `./app.jar` on startup, and can only be modified with commands on startup.
+
 ### Inline
 
+Unless you configure a lot of shell variables, you must write what you want directly in the shell:
+
 ```bash
-docker run ghcr.io/trifork/hapi-fhir-cli:latest
+docker run --rm ghcr.io/trifork/hapi-fhir-cli:latest app.jar migrate-database \
+    -d POSTGRES_9_4 \
+    -u jdbc:postgresql://127.0.0.1:5432/postgres \
+    -n myUser \
+    -p myPassword
 ```
 
-### New image usage
+### Docker Compose
 
-```dockerfile
-FROM ghcr.io/trifork/hapi-fhir-cli:latest AS Final
+For a Docker Compose setup, you can have a `.env`-file with with variables in, and refer them in `command`, as this will substitute them in before the container starts up.
 
-ENV DATABASE_DRIVER=POSTGRES_9_4
-ENV JDBC_DIALECT=jdbc:postgresql
-ENV DB_PORT=5432
-ENV DB_USER=""
-ENV DB_PASSWORD=""
-ENV DB_DATABASE=""
-ENV DB_URL=""
-ENV EXTRA_ARGS="--dry-run"
+```yaml
+services:
 
-ENTRYPOINT ["sh",  "-c", "./hapi-fhir-cli migrate-database -d ${DATABASE_DRIVER} -u ${JDBC_DIALECT}://${DB_URL}:${DB_PORT}/${DB_DATABASE} -n ${DB_USER} -p ${DB_PASSWORD} ${EXTRA_ARGS}"]
+  hapi_fhir_cli_tool:
+    container_name: "HAPI-FHIR-CLI-Tool"
+    image: ghcr.io/trifork/hapi-fhir-cli:latest
+    depends_on:
+      - hapi
+    command: "app.jar migrate-database \
+      -d POSTGRES_9_4 \
+      -u jdbc:postgresql://${DB_URL}:${DB_PORT}/${DB_NAME} \
+      -n ${DB_USERNAME} \
+      -p ${DB_PASSWORD}"
+```
 
+### Kubernetes Job
+
+When spinning up a job in Kubernetes, you can still use secret and variables, but they are still passed in through `command`.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hapi-fhir-cli
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: hapi-fhir-cli
+          image: ghcr.io/trifork/hapi-fhir-cli:latest # Remember to specify version
+          command: ["app.jar"]
+          args: ["migrate-database -d POSTGRES_9_4 -u jdbc:postgresql://${DB_URL}:${DB_PORT}/${DB_NAME} -n ${DB_USERNAME} -p ${DB_PASSWORD}"]
+          env:
+            - name: DB_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: secret-name
+                  key: DB_CONN
+
+            - name: DB_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: secret-name
+                  key: DB_PORT
+
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: POSTGRES_DB
+
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: POSTGRES_USER
+
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: POSTGRES_PASSWORD
+
+          securityContext:
+            runAsUser: 5050
+            runAsGroup: 5050
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
 ```
 
 ## Build an older version
@@ -33,14 +101,17 @@ ENTRYPOINT ["sh",  "-c", "./hapi-fhir-cli migrate-database -d ${DATABASE_DRIVER}
 This repository only builds the newest version per default, but if you are missing and older version, either create an issue here, or push to your own container registry.
 
 Login to Docker using `docker login` for your container registry of choice.
-For GitHub, get a [Personal Access Token](https://github.com/settings/tokens) with both the scopes `write:packages` abd `read:packages`, and [login in your terminal](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
+For GitHub, get a [Personal Access Token](https://github.com/settings/tokens) with both the scopes `write:packages` and `read:packages`, and [login in your terminal](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 Then build a local image, test it, and push it to the repository.
 
 ```bash
-docker build . --build-arg hapi_fhir_version="7.4.5" -t hapi-fhir-cli:7.4.5 # Local image
-docker build . --build-arg hapi_fhir_version="7.4.5" -t ghcr.io/trifork/hapi-fhir-cli:7.4.5 # Tag for GitHub, when pushing for this repository's Container Registry
+# Create an image to use with inline or Docker Compose
+docker build . --build-arg hapi_fhir_version="7.4.5" -t hapi-fhir-cli:7.4.5
 
-#docker push <tag>
+# Create an image for a Container Registry
+docker build . --build-arg hapi_fhir_version="7.4.5" -t ghcr.io/trifork/hapi-fhir-cli:7.4.5
+
+# Push to Container Registry
 docker push ghcr.io/trifork/hapi-fhir-cli:7.4.5
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run --rm ghcr.io/trifork/hapi-fhir-cli:latest app.jar migrate-database \
 
 ### Docker Compose
 
-For a Docker Compose setup, you can have a `.env`-file with with variables in, and refer them in `command`, as this will substitute them in before the container starts up.
+For a Docker Compose setup, you can have a `.env`-file with variables in, and refer them in `command`, as this will substitute them in before the container starts up.
 
 ```yaml
 services:


### PR DESCRIPTION
## New

- Add explanation of why normal variables can't be used to a new image
- Add full example for `docker run`
- Add full example for `docker compose`
- Add full example for Kubernetes `Job`
- Remove example of base image, as this is not doable
- Add better explanation for building new tags