### PR TITLE
Add dependabot, and add cache invalidation for daily run

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Copenhagen"
+    target-branch: "main"

--- a/.github/workflows/upstream-release.yaml
+++ b/.github/workflows/upstream-release.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout/?tab=readme-ov-file#usage
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
         with:
           fetch-depth: 0
           # fetch-tags: true # Does not work for some reason, so we we use fetch-depth: 0
@@ -58,7 +58,8 @@ jobs:
         id: upstream
         run: |
           # https://docs.github.com/en/rest/releases/releases?#get-the-latest-release
-          upstream_version=$(curl -s https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest \
+          upstream_version=$(curl -H 'Cache-Control: no-cache, no-store' -s \
+            https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest \
             | jq -r '.tag_name' | sed 's/v//g')
           # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
           echo "upstream_version=$upstream_version" >> $GITHUB_OUTPUT
@@ -97,7 +98,7 @@ jobs:
       - name: Docker meta
         if: env.NEW_BUILD == 'true'
         id: meta # you'll use this in the next step
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 #v5.10.0
         with:
           # list of Docker images to use as base name for tags
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -116,7 +117,7 @@ jobs:
       - name: Build and push
         if: env.NEW_BUILD == 'true'
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           context: .
           build-args: hapi_fhir_version=${{ steps.upstream.outputs.upstream_version }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ENTRYPOINT ["sh",  "-c", "./hapi-fhir-cli migrate-database -d ${DATABASE_DRIVER}
 This repository only builds the newest version per default, but if you are missing and older version, either create an issue here, or push to your own container registry.
 
 Login to Docker using `docker login` for your container registry of choice.
-For GitHub, get a [Personal Access Token](https://github.com/settings/tokens) with both the scopes `write:packages` abd `read:packages`, and [login in your terminal](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
+For GitHub, get a [Personal Access Token](https://github.com/settings/tokens) with both the scopes `write:packages` and `read:packages`, and [login in your terminal](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 Then build a local image, test it, and push it to the repository.
 


### PR DESCRIPTION
## New

- Add `dependabot.yml` to keep pipelines up to date
- Update `upstream-release.yaml` with SHAs instead of versions (dependabot will update these on updates)

## Fix

- `curl` command in id `upstream` has apparently cached the result, and does not fetch new versions.
  Added cache invalidation.