### PR TITLE
bugfix: Prevent attempting to create tag if nothing has been build

### DIFF
--- a/.github/workflows/upstream-release.yaml
+++ b/.github/workflows/upstream-release.yaml
@@ -138,7 +138,7 @@ jobs:
       # would then prevent the tag from being created.
       # and the failed build would be retried at each schedule.
       - name: Create tag for the new upstream release
-        if: steps.upstream.outputs.upstream_version != steps.tag.outputs.local_version
+        if: env.NEW_BUILD == 'true'
         run: |
           git tag ${{ steps.upstream.outputs.upstream_version }}
           git push origin ${{ steps.upstream.outputs.upstream_version }}


### PR DESCRIPTION
This pull request makes a targeted update to the workflow condition for creating a new release tag. The change ensures that the tag is only created when a new build is actually needed, improving the reliability of the release automation.

Workflow reliability improvement:

* Updated the condition for the "Create tag for the new upstream release" step in `.github/workflows/upstream-release.yaml` to use the `NEW_BUILD` environment variable instead of comparing version outputs, ensuring the tag is only created when a new build is required.