### PR TITLE
bugfix: Fail fast when upstream GitHub API returns null version

### DIFF
--- a/.github/workflows/upstream-release.yaml
+++ b/.github/workflows/upstream-release.yaml
@@ -63,7 +63,7 @@ jobs:
           api_response=$(curl -H 'Cache-Control: no-cache, no-store' \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s \
             https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest)
-          upstream_version=$(echo "$api_response" | jq -r '.tag_name' | sed 's/v//g')
+          upstream_version=$(echo "$api_response" | jq -r '.tag_name | sub("^v"; "")')
           if [[ -z "$upstream_version" || "$upstream_version" == "null" ]]; then
             echo "Failed to get upstream version. API response:"
             echo "$api_response"

--- a/.github/workflows/upstream-release.yaml
+++ b/.github/workflows/upstream-release.yaml
@@ -61,15 +61,18 @@ jobs:
         id: upstream
         run: |
           api_response=$(curl -H 'Cache-Control: no-cache, no-store' \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s \
-            https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest)
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -sS \
+            https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest) || {
+            echo "curl failed with exit code $?"
+            exit 1
+          }
           upstream_version=$(echo "$api_response" | jq -r '.tag_name | sub("^v"; "")')
           if [[ -z "$upstream_version" || "$upstream_version" == "null" ]]; then
             echo "Failed to get upstream version. API response:"
             echo "$api_response"
             exit 1
           fi
-          echo "upstream_version=$upstream_version" >> $GITHUB_OUTPUT
+          echo "upstream_version=$upstream_version" >> "$GITHUB_OUTPUT"
           echo "Found upstream release: \"$upstream_version\""
 
         # https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---sortltkeygt

--- a/.github/workflows/upstream-release.yaml
+++ b/.github/workflows/upstream-release.yaml
@@ -60,7 +60,8 @@ jobs:
       - name: Get the latest upstream release
         id: upstream
         run: |
-          api_response=$(curl -H 'Cache-Control: no-cache, no-store' -s \
+          api_response=$(curl -H 'Cache-Control: no-cache, no-store' \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s \
             https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest)
           upstream_version=$(echo "$api_response" | jq -r '.tag_name' | sed 's/v//g')
           if [[ -z "$upstream_version" || "$upstream_version" == "null" ]]; then

--- a/.github/workflows/upstream-release.yaml
+++ b/.github/workflows/upstream-release.yaml
@@ -60,9 +60,14 @@ jobs:
       - name: Get the latest upstream release
         id: upstream
         run: |
-          upstream_version=$(curl -H 'Cache-Control: no-cache, no-store' -s \
-            https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest \
-            | jq -r '.tag_name' | sed 's/v//g')
+          api_response=$(curl -H 'Cache-Control: no-cache, no-store' -s \
+            https://api.github.com/repos/hapifhir/hapi-fhir/releases/latest)
+          upstream_version=$(echo "$api_response" | jq -r '.tag_name' | sed 's/v//g')
+          if [[ -z "$upstream_version" || "$upstream_version" == "null" ]]; then
+            echo "Failed to get upstream version. API response:"
+            echo "$api_response"
+            exit 1
+          fi
           echo "upstream_version=$upstream_version" >> $GITHUB_OUTPUT
           echo "Found upstream release: \"$upstream_version\""
 


### PR DESCRIPTION
## Summary

- Captures raw API response before parsing `tag_name`
- If version is `null` or empty (e.g. rate-limited without `GITHUB_TOKEN`), prints the full API response and exits with code 1
- No behavior change when API returns a valid release

## Root cause

Running `curl` against latest version of GitHub without `GITHUB_TOKEN` causes GitHub API rate-limiting. The error JSON has no `tag_name`, so `jq` emits `null` and the pipeline silently continued with a null version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)